### PR TITLE
CORS fix

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,14 @@ module TestApi
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', :headers => :any, :methods => [:get, :post, :put, :options]
+      end
+    end
+
     config.api_only = true
   end
 end


### PR DESCRIPTION
Looks like this was removed unintentionally in 93141f0f when we upgraded
to Rails 5.2.